### PR TITLE
Adiciona checagem pela versão do XML

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.0",
+    "version": "1.3.0",
     "name": "sysvale/validation-rules",
     "description": "A Laravel library with useful custom rules",
     "type": "library",

--- a/resources/lang/pt_BR/messages.php
+++ b/resources/lang/pt_BR/messages.php
@@ -4,7 +4,7 @@ return [
 	'max_in_the_zip_file' => 'O arquivo zip deve ter no máximo :quantity arquivo(s).',
 	'not_empty_zip' => 'O arquivo zip não pode está vazio.',
 	'zip_has_xml_file' => 'O arquivo zip deve conter um XML.',
-	'cnes_xml_identification' => 'XML com formato inválido. Por favor, verifique o código do IBGE, o campo de ORIGEM, o campo de DESTINO e a se a versão do XML compatível é a 2.1', // phpcs:ignore
+	'cnes_xml_identification' => 'XML com formato inválido. Por favor, verifique o código do IBGE, o campo de ORIGEM, o campo de DESTINO e a se a versão do XML compatível é a :version_xsd', // phpcs:ignore
 	'cnes_xml_structure' => 'A estrutura do arquivo XML está inválida.',
 	'cnes_xml_date' => 'A competência do XML deve ser posterior a data :date.',
 ];

--- a/resources/lang/pt_BR/messages.php
+++ b/resources/lang/pt_BR/messages.php
@@ -4,7 +4,7 @@ return [
 	'max_in_the_zip_file' => 'O arquivo zip deve ter no máximo :quantity arquivo(s).',
 	'not_empty_zip' => 'O arquivo zip não pode está vazio.',
 	'zip_has_xml_file' => 'O arquivo zip deve conter um XML.',
-	'cnes_xml_identification' => 'XML com formato inválido. Por favor, verifique o código do IBGE, o campo de ORIGEM e o campo de DESTINO.', // phpcs:ignore
+	'cnes_xml_identification' => 'XML com formato inválido. Por favor, verifique o código do IBGE, o campo de ORIGEM, o campo de DESTINO e a se a versão do XML compatível é a 2.1', // phpcs:ignore
 	'cnes_xml_structure' => 'A estrutura do arquivo XML está inválida.',
 	'cnes_xml_date' => 'A competência do XML deve ser posterior a data :date.',
 ];

--- a/src/Rules/CnesXMLIdentification.php
+++ b/src/Rules/CnesXMLIdentification.php
@@ -10,7 +10,7 @@ class CnesXMLIdentification implements Rule
 {
 	private $expected_ibge_code;
 
-	public function __construct($expected_ibge_code, $version_xsd)
+	public function __construct($expected_ibge_code, $version_xsd = '2.1')
 	{
 		$this->expected_ibge_code = $expected_ibge_code;
 		$this->version_xsd = $version_xsd;

--- a/src/Rules/CnesXMLIdentification.php
+++ b/src/Rules/CnesXMLIdentification.php
@@ -42,7 +42,9 @@ class CnesXMLIdentification implements Rule
 	 */
 	public function message()
 	{
-		return __('SysvaleValidationRules::messages.cnes_xml_identification');
+		return __('SysvaleValidationRules::messages.cnes_xml_identification', [
+			'version_xsd' => $this->version_xsd,
+		]);
 	}
 
 

--- a/src/Rules/CnesXMLIdentification.php
+++ b/src/Rules/CnesXMLIdentification.php
@@ -61,7 +61,7 @@ class CnesXMLIdentification implements Rule
 			if ($origin === 'PORTAL'
 				&& $target === 'ESUS_AB'
 				&& $ibge_code === $this->expected_ibge_code
-				&& ($version_xsd != null && $version_xsd === $this->version_xsd)
+				&& $version_xsd === $this->version_xsd
 			) {
 				return true;
 			}

--- a/src/Rules/CnesXMLIdentification.php
+++ b/src/Rules/CnesXMLIdentification.php
@@ -10,9 +10,10 @@ class CnesXMLIdentification implements Rule
 {
 	private $expected_ibge_code;
 
-	public function __construct($expected_ibge_code)
+	public function __construct($expected_ibge_code, $version_xsd)
 	{
 		$this->expected_ibge_code = $expected_ibge_code;
+		$this->version_xsd = $version_xsd;
 	}
 
 	/**
@@ -55,10 +56,12 @@ class CnesXMLIdentification implements Rule
 			$origin = (string) $identification['ORIGEM'];
 			$target = (string) $identification['DESTINO'];
 			$ibge_code = (string) $identification['CO_IBGE_MUN'];
+			$version_xsd = (string) $identification['VERSION_XSD'];
 
 			if ($origin === 'PORTAL'
 				&& $target === 'ESUS_AB'
 				&& $ibge_code === $this->expected_ibge_code
+				&& ($version_xsd != null && $version_xsd === $this->version_xsd)
 			) {
 				return true;
 			}

--- a/src/Rules/ZipHasValidCnesXML.php
+++ b/src/Rules/ZipHasValidCnesXML.php
@@ -12,10 +12,11 @@ class ZipHasValidCnesXML implements Rule
 	private $date;
 	protected $message;
 
-	public function __construct($expected_ibge_code, $date = null)
+	public function __construct($expected_ibge_code, $date = null, $version_xsd = '2.1')
 	{
 		$this->expected_ibge_code = $expected_ibge_code;
 		$this->date = $date;
+		$this->version_xsd = $version_xsd;
 	}
 
 	/**
@@ -56,7 +57,7 @@ class ZipHasValidCnesXML implements Rule
 
 	protected function hasValidIdentification($attribute, $value)
 	{
-		$rule = new CnesXMLIdentification($this->expected_ibge_code);
+		$rule = new CnesXMLIdentification($this->expected_ibge_code, $this->version_xsd);
 
 		return $this->validateWithRule($rule, $attribute, $value);
 	}

--- a/src/Rules/ZipHasValidCnesXML.php
+++ b/src/Rules/ZipHasValidCnesXML.php
@@ -12,7 +12,7 @@ class ZipHasValidCnesXML implements Rule
 	private $date;
 	protected $message;
 
-	public function __construct($expected_ibge_code, $date = null, $version_xsd = '2.1')
+	public function __construct($expected_ibge_code, $date = null, $version_xsd = null)
 	{
 		$this->expected_ibge_code = $expected_ibge_code;
 		$this->date = $date;

--- a/tests/Support/CnesXMLContentsHandler.php
+++ b/tests/Support/CnesXMLContentsHandler.php
@@ -15,7 +15,7 @@ trait CnesXMLContentsHandler
 		if (is_null($contents)) {
 			$ibge_code = $data['ibge_code'] ?? '';
 			$date = $data['date'] ?? '';
-			$version_xsd = $data['version_xsd'] ?? '';
+			$version_xsd = $data['version_xsd'] ?? 'VERSION_XSD="2.1"';
 
 			$contents = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>
 				<ImportarXMLCNES>
@@ -26,6 +26,8 @@ trait CnesXMLContentsHandler
 						</PROFISSIONAIS>\r\n
 					</IDENTIFICACAO>\r\n
 				</ImportarXMLCNES>\r\n";
+
+				dump($contents);
 		}
 
 		$handler_mock = Mockery::mock(ZipWithXMLHandler::class)->makePartial();

--- a/tests/Support/CnesXMLContentsHandler.php
+++ b/tests/Support/CnesXMLContentsHandler.php
@@ -26,8 +26,6 @@ trait CnesXMLContentsHandler
 						</PROFISSIONAIS>\r\n
 					</IDENTIFICACAO>\r\n
 				</ImportarXMLCNES>\r\n";
-
-				dump($contents);
 		}
 
 		$handler_mock = Mockery::mock(ZipWithXMLHandler::class)->makePartial();

--- a/tests/Support/CnesXMLContentsHandler.php
+++ b/tests/Support/CnesXMLContentsHandler.php
@@ -15,10 +15,11 @@ trait CnesXMLContentsHandler
 		if (is_null($contents)) {
 			$ibge_code = $data['ibge_code'] ?? '';
 			$date = $data['date'] ?? '';
+			$version_xsd = $data['version_xsd'] ?? '';
 
 			$contents = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>
 				<ImportarXMLCNES>
-					<IDENTIFICACAO DATA=\"$date\" ORIGEM=\"PORTAL\" DESTINO=\"ESUS_AB\" CO_IBGE_MUN=\"$ibge_code\">\r\n
+					<IDENTIFICACAO DATA=\"$date\" ORIGEM=\"PORTAL\" DESTINO=\"ESUS_AB\" CO_IBGE_MUN=\"$ibge_code\" $version_xsd>\r\n
 						<ESTABELECIMENTOS>\r\n
 						</ESTABELECIMENTOS>\r\n
 						<PROFISSIONAIS>\r\n

--- a/tests/Unit/Rules/CnesXMLIdentificationTest.php
+++ b/tests/Unit/Rules/CnesXMLIdentificationTest.php
@@ -16,11 +16,10 @@ class CnesXMLIdentificationTest extends TestCase
 	public function testPasses()
 	{
 		$ibge_code = '12345';
-		$version_xsd = '2.1';
 
-		$this->mockXmlContents(['ibge_code' => $ibge_code, 'version_xsd' => "VERSION_XSD=\"$version_xsd\""]);
+		$this->mockXmlContents(['ibge_code' => $ibge_code]);
 
-		$rule = new CnesXMLIdentification($ibge_code, $version_xsd);
+		$rule = new CnesXMLIdentification($ibge_code, '2.1');
 
 		$this->assertTrue($rule->passes('file', UploadedFile::fake()->create('xml.zip')));
 	}
@@ -29,7 +28,7 @@ class CnesXMLIdentificationTest extends TestCase
 	{
 		$ibge_code = '12345';
 
-		$this->mockXmlContents(['ibge_code' => $ibge_code]);
+		$this->mockXmlContents(['ibge_code' => $ibge_code, 'version_xsd' => '']);
 
 		$rule = new CnesXMLIdentification($ibge_code, '2.1');
 

--- a/tests/Unit/Rules/CnesXMLIdentificationTest.php
+++ b/tests/Unit/Rules/CnesXMLIdentificationTest.php
@@ -16,11 +16,36 @@ class CnesXMLIdentificationTest extends TestCase
 	public function testPasses()
 	{
 		$ibge_code = '12345';
-		$this->mockXmlContents(['ibge_code' => $ibge_code]);
+		$version_xsd = '2.1';
 
-		$rule = new CnesXMLIdentification($ibge_code);
+		$this->mockXmlContents(['ibge_code' => $ibge_code, 'version_xsd' => "VERSION_XSD=\"$version_xsd\""]);
+
+		$rule = new CnesXMLIdentification($ibge_code, $version_xsd);
 
 		$this->assertTrue($rule->passes('file', UploadedFile::fake()->create('xml.zip')));
+	}
+
+	public function testNotPassesVersionXSD()
+	{
+		$ibge_code = '12345';
+
+		$this->mockXmlContents(['ibge_code' => $ibge_code]);
+
+		$rule = new CnesXMLIdentification($ibge_code, '2.1');
+
+		$this->assertFalse($rule->passes('file', UploadedFile::fake()->create('xml.zip')));
+	}
+
+	public function testNotPassesVersionXSDDiff2_1()
+	{
+		$ibge_code = '12345';
+		$version_xsd = '3.0';
+
+		$this->mockXmlContents(['ibge_code' => $ibge_code, 'version_xsd' => "VERSION_XSD=\"$version_xsd\""]);
+
+		$rule = new CnesXMLIdentification($ibge_code, '2.1');
+
+		$this->assertFalse($rule->passes('file', UploadedFile::fake()->create('xml.zip')));
 	}
 
 	/**
@@ -29,8 +54,8 @@ class CnesXMLIdentificationTest extends TestCase
 	public function testIdentificationErrorMessage()
 	{
 		$this->assertSame(
-			'XML com formato inválido. Por favor, verifique o código do IBGE, o campo de ORIGEM e o campo de DESTINO.',
-			$this->getErrorMessage(CnesXMLIdentification::class, ['0000'])
+			'XML com formato inválido. Por favor, verifique o código do IBGE, o campo de ORIGEM, o campo de DESTINO e a se a versão do XML compatível é a 2.1',
+			$this->getErrorMessage(CnesXMLIdentification::class, ['0000', '2.1'])
 		);
 	}
 }

--- a/tests/Unit/Rules/CnesXMLIdentificationTest.php
+++ b/tests/Unit/Rules/CnesXMLIdentificationTest.php
@@ -35,12 +35,15 @@ class CnesXMLIdentificationTest extends TestCase
 		$this->assertFalse($rule->passes('file', UploadedFile::fake()->create('xml.zip')));
 	}
 
-	public function testNotPassesVersionXSDDiff2_1()
+	public function testNotPassesVersionXSDDiff21()
 	{
 		$ibge_code = '12345';
 		$version_xsd = '3.0';
 
-		$this->mockXmlContents(['ibge_code' => $ibge_code, 'version_xsd' => "VERSION_XSD=\"$version_xsd\""]);
+		$this->mockXmlContents([
+			'ibge_code' => $ibge_code,
+			'version_xsd' => "VERSION_XSD=\"$version_xsd\""
+		]);
 
 		$rule = new CnesXMLIdentification($ibge_code, '2.1');
 

--- a/tests/Unit/Rules/CnesXMLIdentificationTest.php
+++ b/tests/Unit/Rules/CnesXMLIdentificationTest.php
@@ -50,6 +50,20 @@ class CnesXMLIdentificationTest extends TestCase
 		$this->assertFalse($rule->passes('file', UploadedFile::fake()->create('xml.zip')));
 	}
 
+	public function testSecondArgumentIsntPassed()
+	{
+		$ibge_code = '12345';
+
+		$this->mockXmlContents([
+			'ibge_code' => $ibge_code,
+			'version_xsd' => "VERSION_XSD=\"2.1\""
+		]);
+
+		$rule = new CnesXMLIdentification($ibge_code);
+
+		$this->assertTrue($rule->passes('file', UploadedFile::fake()->create('xml.zip')));
+	}
+
 	/**
 	 * @phpcs:disable Generic.Files.LineLength.TooLong
 	 */

--- a/tests/Unit/Rules/ZipHasValidCnesXMLTest.php
+++ b/tests/Unit/Rules/ZipHasValidCnesXMLTest.php
@@ -66,19 +66,23 @@ class ZipHasValidCnesXMLTest extends TestCase
 
 		$this->assertFalse($passes);
 		$this->assertEquals(
-			'XML com formato inválido. Por favor, verifique o código do IBGE, o campo de ORIGEM e o campo de DESTINO.', //phpcs:ignore
+			'XML com formato inválido. Por favor, verifique o código do IBGE, o campo de ORIGEM, o campo de DESTINO e a se a versão do XML compatível é a 2.1', //phpcs:ignore
 			$validator->errors()->first('file')
 		);
 	}
 
 	public function testFileWithInvalidDate()
 	{
-		$this->mockXmlContents(['ibge_code' => '', 'date' => '2020-10-10']);
+		$this->mockXmlContents([
+			'ibge_code' => '',
+			'date' =>'2020-10-10',
+			'version_xsd' => 'VERSION_XSD="2.1"'
+		]);
 
 		$validator = Validator::make([
 			'file' => UploadedFile::fake()->create('xml.zip'),
 		], [
-			'file' => [new ZipHasValidCnesXML('', '2020-10-10')],
+			'file' => [new ZipHasValidCnesXML('', '2020-10-10', $version_xsd='2.1')],
 		]);
 
 		$passes = $validator->passes();
@@ -94,7 +98,7 @@ class ZipHasValidCnesXMLTest extends TestCase
 	{
 		$this->mockXmlContents(['ibge_code' => '123456', 'date' => '2020-10-10']);
 
-		$rule = new ZipHasValidCnesXML('123456', '2020-10-09');
+		$rule = new ZipHasValidCnesXML('123456', '2020-10-09', '2.1');
 
 		$passes = $rule->passes('file', UploadedFile::fake()->create('xml.zip'));
 

--- a/tests/Unit/Rules/ZipHasValidCnesXMLTest.php
+++ b/tests/Unit/Rules/ZipHasValidCnesXMLTest.php
@@ -82,7 +82,7 @@ class ZipHasValidCnesXMLTest extends TestCase
 		$validator = Validator::make([
 			'file' => UploadedFile::fake()->create('xml.zip'),
 		], [
-			'file' => [new ZipHasValidCnesXML('', '2020-10-10', $version_xsd='2.1')],
+			'file' => [new ZipHasValidCnesXML('', '2020-10-10', $version_xsd = '2.1')],
 		]);
 
 		$passes = $validator->passes();


### PR DESCRIPTION
A versão do xml compatível deve ser a 2.1

Esse valor fica disponível no atributo VERSION_XSD do elemento IDENTIFICACAO.

Criei testes e alterei a mensagem de erro.